### PR TITLE
Allow disabling stick play

### DIFF
--- a/tm_driver/launch/tm12_bringup.launch
+++ b/tm_driver/launch/tm12_bringup.launch
@@ -10,6 +10,7 @@
   <arg name="robot_ip" />
   <arg name="min_payload" default="0.0" />
   <arg name="max_payload" default="12.0" />
+  <arg name="auto_stick_play" default="true" />
 
   <!-- robot model -->
   <!--
@@ -23,6 +24,7 @@
     <arg name="robot_ip" value="$(arg robot_ip)" />
     <arg name="min_payload" value="$(arg min_payload)" />
     <arg name="max_payload" value="$(arg max_payload)" />
+    <arg name="auto_stick_play" value="$(arg auto_stick_play)" />
   </include>
 
 </launch>

--- a/tm_driver/launch/tm5_700_bringup.launch
+++ b/tm_driver/launch/tm5_700_bringup.launch
@@ -10,6 +10,7 @@
   <arg name="robot_ip" />
   <arg name="min_payload" default="0.0" />
   <arg name="max_payload" default="6.0" />
+  <arg name="auto_stick_play" default="true" />
 
   <!-- robot model -->
   <!--
@@ -23,6 +24,7 @@
     <arg name="robot_ip" value="$(arg robot_ip)" />
     <arg name="min_payload" value="$(arg min_payload)" />
     <arg name="max_payload" value="$(arg max_payload)" />
+    <arg name="auto_stick_play" value="$(arg auto_stick_play)" />
   </include>
 
 </launch>

--- a/tm_driver/launch/tm5_900_bringup.launch
+++ b/tm_driver/launch/tm5_900_bringup.launch
@@ -10,7 +10,7 @@
   <arg name="robot_ip" />
   <arg name="min_payload" default="0.0" />
   <arg name="max_payload" default="4.0" />
-
+  <arg name="auto_stick_play" default="true" />
   <!-- robot model -->
   <!--
   <include file="$(find tm5_description)/launch/tm5_900_upload.launch">
@@ -23,6 +23,7 @@
     <arg name="robot_ip" value="$(arg robot_ip)" />
     <arg name="min_payload" value="$(arg min_payload)" />
     <arg name="max_payload" value="$(arg max_payload)" />
+    <arg name="auto_stick_play" value="$(arg auto_stick_play)" />
   </include>
 
 </launch>

--- a/tm_driver/launch/tm_common.launch
+++ b/tm_driver/launch/tm_common.launch
@@ -14,6 +14,7 @@
   <arg name="max_payload" default="6.0" /> <!-- [kg] -->
   <arg name="base_frame" default="$(arg prefix)base" />
   <arg name="tool_frame" default="$(arg prefix)tool0" />
+  <arg name="auto_stick_play" default="true" />
 
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
 
@@ -26,5 +27,6 @@
     <param name="max_payload" type="double" value="$(arg max_payload)" />
     <param name="base_frame" type="str" value="$(arg base_frame)" />
     <param name="tool_frame" type="str" value="$(arg tool_frame)" />
+    <param name="auto_stick_play" type="bool" value="$(arg auto_stick_play)" />
   </node>
 </launch>

--- a/tm_driver/src/tm_ros_node.cpp
+++ b/tm_driver/src/tm_ros_node.cpp
@@ -41,10 +41,15 @@ TmRosNode::TmRosNode(const std::string &host)
     }
     tool_frame_name_ = prefix + frame_name;
 
+    bool auto_stick_play = true;
+    if (ros::param::get("~auto_stick_play", auto_stick_play)) {
+        print_info("TM_ROS: set auto_stick_play to %d", auto_stick_play);
+    }
+
     ////////////////////////////////
     // TmDriver
     ////////////////////////////////
-    iface_.start(5000);
+    iface_.start(5000, auto_stick_play);
 
     ////////////////////////////////
     // Topic


### PR DESCRIPTION
When starting the tm_driver we can use the stick_play value to control whether or not the robot will "press" the stick play button.

The ROS node however does not use that feature, always using the default true value. This means that starting the driver will start the default program on the robot if it is in Auto mode. This is a potential safety issue.

By adding a parameter to the rosnode as well as arguments to the corresponding launch files we can allow the user to enable or disable that behavior. To ensure backward compatibility, default values are provided to keep the previous behavior.