### PR TITLE
Correct default kinematic values

### DIFF
--- a/tm12_description/config/tm12_default.yaml
+++ b/tm12_description/config/tm12_default.yaml
@@ -1,3 +1,4 @@
+# See Chapter 4.2.1.1 of https://assets.omron.eu/downloads/manual/en/v2/i624_tm12_and_tm14_hardware_installation_manual_en.pdf
 kinematics:
   shoulder_1:
     x: 0.0
@@ -36,7 +37,7 @@ kinematics:
     yaw: 0.0
   wrist_3:
     x: 0.0
-    y: -0.1144
+    y: -0.11315
     z: 0.0
     roll: 1.5707963267948966
     pitch: -0.0

--- a/tm5_description/config/tm5_700_default.yaml
+++ b/tm5_description/config/tm5_700_default.yaml
@@ -1,8 +1,9 @@
+# See Chapter 4.2.1.1 of https://assets.omron.eu/downloads/manual/en/v6/i623_tm5_series_installation_manual_en.pdf
 kinematics:
   shoulder_1:
     x: 0.0
     y: 0.0
-    z: 0.1451
+    z: 0.1452
     roll: 0.0
     pitch: -0.0
     yaw: 0.0
@@ -23,7 +24,7 @@ kinematics:
   wrist_1:
     x: 0.3115
     y: 0.0
-    z: -0.1222
+    z: -0.1223
     roll: 0.0
     pitch: -0.0
     yaw: 1.5707963267948966
@@ -36,7 +37,7 @@ kinematics:
     yaw: 0.0
   wrist_3:
     x: 0.0
-    y: -0.1144
+    y: -0.11315
     z: 0.0
     roll: 1.5707963267948966
     pitch: -0.0

--- a/tm5_description/config/tm5_900_default.yaml
+++ b/tm5_description/config/tm5_900_default.yaml
@@ -1,8 +1,9 @@
+# See Chapter 4.2.1.1 of https://assets.omron.eu/downloads/manual/en/v6/i623_tm5_series_installation_manual_en.pdf
 kinematics:
   shoulder_1:
     x: 0.0
     y: 0.0
-    z: 0.1451
+    z: 0.1452
     roll: 0.0
     pitch: -0.0
     yaw: 0.0


### PR DESCRIPTION
Support for bringing up TM robots with kinematic factory calibrations was added in https://github.com/ascentai/tmr_ros1/pull/5. It turns out that the YAMLs containing default kinematic values for each robot had some small errors in it, resulting in upstream FK/IK tests failing with ~2mm discrepancies.

This PR corrects the kinematics files which was shown to fix the related tests.

I also added links to PDF files where the values were taken from.