### PR TITLE
Delete comments which have a variable

### DIFF
--- a/tm12_description/urdf/tm12_robot.urdf.xacro
+++ b/tm12_description/urdf/tm12_robot.urdf.xacro
@@ -1,8 +1,6 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://wiki.ros.org/xacro" name="tm12">
 
-  <!--xacro:arg name="transmission_hw_interface" default="hardware_interface/PositionJointInterface"/-->
-
   <!-- common stuff -->
   <xacro:include filename="$(find tm5_description)/urdf/common.gazebo.xacro" />
 
@@ -10,7 +8,6 @@
   <xacro:include filename="$(find tm12_description)/urdf/tm12.urdf.xacro" />
 
   <!-- arm -->
-  <!--xacro:tm12_robot prefix="" joint_limited="false" transmission_hw_interface="$(arg transmission_hw_interface)" /-->
   <xacro:arg name="kinematics_config" default="$(find tm12_description)/config/tm12_default.yaml" />
   <xacro:tm12_robot prefix="" joint_limited="false" stl_mesh="$(arg stl_mesh)" kinematics_file="${load_yaml('$(arg kinematics_config)')}" />
 

--- a/tm5_description/urdf/tm5_700_robot.urdf.xacro
+++ b/tm5_description/urdf/tm5_700_robot.urdf.xacro
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://wiki.ros.org/xacro" name="tm5_700">
 
-  <!-- xacro:arg name="transmission_hw_interface" default="hardware_interface/PositionJointInterface"/-->
   <xacro:arg name="stl_mesh" default="false"/>
 
   <!-- common stuff -->
@@ -11,7 +10,6 @@
   <xacro:include filename="$(find tm5_description)/urdf/tm5_700.urdf.xacro" />
 
   <!-- arm -->
-  <!--xacro:tm5_700_robot prefix="" joint_limited="false" transmission_hw_interface="$(arg transmission_hw_interface)" /-->
   <xacro:arg name="kinematics_config" default="$(find tm5_description)/config/tm5_700_default.yaml" />
   <xacro:tm5_700_robot prefix="" joint_limited="false" stl_mesh="$(arg stl_mesh)" kinematics_file="${load_yaml('$(arg kinematics_config)')}" />
 

--- a/tm5_description/urdf/tm5_900_robot.urdf.xacro
+++ b/tm5_description/urdf/tm5_900_robot.urdf.xacro
@@ -1,8 +1,6 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://wiki.ros.org/xacro" name="tm5_900" >
 
-  <!--xacro:arg name="transmission_hw_interface" default="hardware_interface/PositionJointInterface"/-->
-  <!--xacro:arg name="stl_mesh" default="false"/-->
 
   <!-- common stuff -->
   <xacro:include filename="$(find tm5_description)/urdf/common.gazebo.xacro" />
@@ -11,7 +9,6 @@
   <xacro:include filename="$(find tm5_description)/urdf/tm5_900.urdf.xacro" />
 
   <!-- arm -->
-  <!--xacro:tm5_900_robot prefix="" joint_limited="false" transmission_hw_interface="$(arg transmission_hw_interface)" /-->
   <xacro:arg name="kinematics_config" default="$(find tm5_description)/config/tm5_900_default.yaml" />
   <xacro:tm5_900_robot prefix="" joint_limited="false" stl_mesh="$(arg stl_mesh)" kinematics_file="${load_yaml('$(arg kinematics_config)')}" />
 


### PR DESCRIPTION
The variable is evaluated regardless the variable is in comment at xarco ~1.13.16~  1.13.15 version. So we can't include undefined variables in comments. We can confirm the behavior by running `xacro tm12_description/urdf/tm12_robot.urdf.xacro stl_mesh:=false` with and without the comments. 